### PR TITLE
simple callback call

### DIFF
--- a/lib/query.ts
+++ b/lib/query.ts
@@ -22,9 +22,7 @@ export function queryParser(options: any = null) {
         }
       }
       ctx.request.query = queryParams;
-      next();
-    } else {
-      next();
     }
+    next();
   };
 }


### PR DESCRIPTION
The callbcak `next()` can be called just in one place at the end of the operation, as there is no scenario where the callback would be bypassed.